### PR TITLE
[#32] Encyclopedia & Context Card Association

### DIFF
--- a/gardenbook-db-api/src/routes/users.js
+++ b/gardenbook-db-api/src/routes/users.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const userModel = require('../models/user');
 const { ObjectId } = require('mongodb');
+const { authenticateToken } = require('../middleware/auth');
 
 /**
  * @swagger
@@ -55,6 +56,8 @@ router.post('/', async (req, res) => {
  *   get:
  *     summary: Retrieve a user's encyclopedia data
  *     description: Retrieve the encyclopedia data for a specific user
+ *     security:
+ *       - bearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -72,12 +75,16 @@ router.post('/', async (req, res) => {
  *               properties:
  *                 encyclopedia:
  *                   type: string
+ *       401:
+ *         description: Unauthorized - authentication required
+ *       403:
+ *         description: Forbidden - user can only access their own data
  *       404:
  *         description: User not found
  *       500:
  *         description: Server error
  */
-router.get('/:id/encyclopedia', async (req, res) => {
+router.get('/:id/encyclopedia', authenticateToken, async (req, res) => {
   const id = req.params.id;
   console.log(`[GET /users/${id}/encyclopedia] Request received`);
   
@@ -86,6 +93,12 @@ router.get('/:id/encyclopedia', async (req, res) => {
     if (!ObjectId.isValid(id)) {
       console.log(`[GET /users/${id}/encyclopedia] Invalid ObjectId: ${id}`);
       return res.status(400).json({ error: 'Invalid user ID format' });
+    }
+    
+    // Verify that the authenticated user is accessing their own data
+    if (req.user.userId !== id) {
+      console.log(`[GET /users/${id}/encyclopedia] Unauthorized access attempt by user ${req.user.userId}`);
+      return res.status(403).json({ error: 'You can only access your own encyclopedia data' });
     }
     
     const encyclopedia = await userModel.getEncyclopedia(id);
@@ -108,6 +121,8 @@ router.get('/:id/encyclopedia', async (req, res) => {
  *   post:
  *     summary: Create or update a user's encyclopedia data
  *     description: Create or update the encyclopedia data for a specific user
+ *     security:
+ *       - bearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -139,12 +154,16 @@ router.get('/:id/encyclopedia', async (req, res) => {
  *                   type: string
  *       400:
  *         description: Invalid request data
+ *       401:
+ *         description: Unauthorized - authentication required
+ *       403:
+ *         description: Forbidden - user can only update their own data
  *       404:
  *         description: User not found
  *       500:
  *         description: Server error
  */
-router.post('/:id/encyclopedia', async (req, res) => {
+router.post('/:id/encyclopedia', authenticateToken, async (req, res) => {
   const id = req.params.id;
   console.log(`[POST /users/${id}/encyclopedia] Request received with body:`, req.body);
   
@@ -153,6 +172,12 @@ router.post('/:id/encyclopedia', async (req, res) => {
     if (!ObjectId.isValid(id)) {
       console.log(`[POST /users/${id}/encyclopedia] Invalid ObjectId: ${id}`);
       return res.status(400).json({ error: 'Invalid user ID format' });
+    }
+    
+    // Verify that the authenticated user is updating their own data
+    if (req.user.userId !== id) {
+      console.log(`[POST /users/${id}/encyclopedia] Unauthorized access attempt by user ${req.user.userId}`);
+      return res.status(403).json({ error: 'You can only update your own encyclopedia data' });
     }
     
     // Validate request body
@@ -182,6 +207,8 @@ router.post('/:id/encyclopedia', async (req, res) => {
  *   get:
  *     summary: Retrieve a user's context cards
  *     description: Retrieve all context cards for a specific user
+ *     security:
+ *       - bearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -214,12 +241,16 @@ router.post('/:id/encyclopedia', async (req, res) => {
  *                       updatedAt:
  *                         type: string
  *                         format: date-time
+ *       401:
+ *         description: Unauthorized - authentication required
+ *       403:
+ *         description: Forbidden - user can only access their own data
  *       404:
  *         description: User not found
  *       500:
  *         description: Server error
  */
-router.get('/:id/context-cards', async (req, res) => {
+router.get('/:id/context-cards', authenticateToken, async (req, res) => {
   const id = req.params.id;
   console.log(`[GET /users/${id}/context-cards] Request received`);
   
@@ -228,6 +259,12 @@ router.get('/:id/context-cards', async (req, res) => {
     if (!ObjectId.isValid(id)) {
       console.log(`[GET /users/${id}/context-cards] Invalid ObjectId: ${id}`);
       return res.status(400).json({ error: 'Invalid user ID format' });
+    }
+    
+    // Verify that the authenticated user is accessing their own data
+    if (req.user.userId !== id) {
+      console.log(`[GET /users/${id}/context-cards] Unauthorized access attempt by user ${req.user.userId}`);
+      return res.status(403).json({ error: 'You can only access your own context cards' });
     }
     
     const contextCards = await userModel.getContextCards(id);
@@ -250,6 +287,8 @@ router.get('/:id/context-cards', async (req, res) => {
  *   post:
  *     summary: Create a new context card
  *     description: Create a new context card for a specific user
+ *     security:
+ *       - bearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -298,12 +337,16 @@ router.get('/:id/context-cards', async (req, res) => {
  *                       format: date-time
  *       400:
  *         description: Invalid request data
+ *       401:
+ *         description: Unauthorized - authentication required
+ *       403:
+ *         description: Forbidden - user can only create their own context cards
  *       404:
  *         description: User not found
  *       500:
  *         description: Server error
  */
-router.post('/:id/context-cards', async (req, res) => {
+router.post('/:id/context-cards', authenticateToken, async (req, res) => {
   const id = req.params.id;
   console.log(`[POST /users/${id}/context-cards] Request received with body:`, req.body);
   
@@ -312,6 +355,12 @@ router.post('/:id/context-cards', async (req, res) => {
     if (!ObjectId.isValid(id)) {
       console.log(`[POST /users/${id}/context-cards] Invalid ObjectId: ${id}`);
       return res.status(400).json({ error: 'Invalid user ID format' });
+    }
+    
+    // Verify that the authenticated user is creating context cards for their own account
+    if (req.user.userId !== id) {
+      console.log(`[POST /users/${id}/context-cards] Unauthorized access attempt by user ${req.user.userId}`);
+      return res.status(403).json({ error: 'You can only create context cards for your own account' });
     }
     
     // Validate request body
@@ -345,6 +394,8 @@ router.post('/:id/context-cards', async (req, res) => {
  *   put:
  *     summary: Update a context card
  *     description: Update a specific context card for a user
+ *     security:
+ *       - bearerAuth: []
  *     parameters:
  *       - in: path
  *         name: userId
@@ -399,12 +450,16 @@ router.post('/:id/context-cards', async (req, res) => {
  *                       format: date-time
  *       400:
  *         description: Invalid request data
+ *       401:
+ *         description: Unauthorized - authentication required
+ *       403:
+ *         description: Forbidden - user can only update their own context cards
  *       404:
  *         description: User or context card not found
  *       500:
  *         description: Server error
  */
-router.put('/:userId/context-cards/:cardId', async (req, res) => {
+router.put('/:userId/context-cards/:cardId', authenticateToken, async (req, res) => {
   const userId = req.params.userId;
   const cardId = req.params.cardId;
   console.log(`[PUT /users/${userId}/context-cards/${cardId}] Request received with body:`, req.body);
@@ -414,6 +469,12 @@ router.put('/:userId/context-cards/:cardId', async (req, res) => {
     if (!ObjectId.isValid(userId)) {
       console.log(`[PUT /users/${userId}/context-cards/${cardId}] Invalid user ObjectId: ${userId}`);
       return res.status(400).json({ error: 'Invalid user ID format' });
+    }
+    
+    // Verify that the authenticated user is updating their own context card
+    if (req.user.userId !== userId) {
+      console.log(`[PUT /users/${userId}/context-cards/${cardId}] Unauthorized access attempt by user ${req.user.userId}`);
+      return res.status(403).json({ error: 'You can only update your own context cards' });
     }
     
     // Validate request body
@@ -447,6 +508,8 @@ router.put('/:userId/context-cards/:cardId', async (req, res) => {
  *   delete:
  *     summary: Delete a context card
  *     description: Delete a specific context card for a user
+ *     security:
+ *       - bearerAuth: []
  *     parameters:
  *       - in: path
  *         name: userId
@@ -473,12 +536,16 @@ router.put('/:userId/context-cards/:cardId', async (req, res) => {
  *                   example: true
  *       400:
  *         description: Invalid request data
+ *       401:
+ *         description: Unauthorized - authentication required
+ *       403:
+ *         description: Forbidden - user can only delete their own context cards
  *       404:
  *         description: User or context card not found
  *       500:
  *         description: Server error
  */
-router.delete('/:userId/context-cards/:cardId', async (req, res) => {
+router.delete('/:userId/context-cards/:cardId', authenticateToken, async (req, res) => {
   const userId = req.params.userId;
   const cardId = req.params.cardId;
   console.log(`[DELETE /users/${userId}/context-cards/${cardId}] Request received`);
@@ -488,6 +555,12 @@ router.delete('/:userId/context-cards/:cardId', async (req, res) => {
     if (!ObjectId.isValid(userId)) {
       console.log(`[DELETE /users/${userId}/context-cards/${cardId}] Invalid user ObjectId: ${userId}`);
       return res.status(400).json({ error: 'Invalid user ID format' });
+    }
+    
+    // Verify that the authenticated user is deleting their own context card
+    if (req.user.userId !== userId) {
+      console.log(`[DELETE /users/${userId}/context-cards/${cardId}] Unauthorized access attempt by user ${req.user.userId}`);
+      return res.status(403).json({ error: 'You can only delete your own context cards' });
     }
     
     // Delete context card

--- a/gardenbook-db-api/tests/encyclopedia-context-auth.test.js
+++ b/gardenbook-db-api/tests/encyclopedia-context-auth.test.js
@@ -1,0 +1,217 @@
+// Mock the dependencies
+jest.mock('../src/models/user', () => ({
+  getEncyclopedia: jest.fn(),
+  updateEncyclopedia: jest.fn(),
+  getContextCards: jest.fn(),
+  createContextCard: jest.fn(),
+  updateContextCard: jest.fn(),
+  deleteContextCard: jest.fn()
+}));
+
+// Mock the auth middleware
+jest.mock('../src/middleware/auth', () => ({
+  authenticateToken: jest.fn((req, res, next) => {
+    // If authorization header is present, extract the token
+    const authHeader = req.headers['authorization'];
+    const token = authHeader && authHeader.split(' ')[1];
+    
+    if (!token) {
+      return res.status(401).json({ error: 'Authentication required' });
+    }
+
+    // Simulate token verification for our test tokens
+    if (token === 'valid_token_for_user1') {
+      req.user = { userId: '507f1f77bcf86cd799439011' };
+      next();
+    } else if (token === 'valid_token_for_user2') {
+      req.user = { userId: '507f1f77bcf86cd799439022' };
+      next();
+    } else {
+      return res.status(401).json({ error: 'Invalid or expired token' });
+    }
+  }),
+  authenticateJwt: jest.fn((req, res, next) => next()),
+  isAdmin: jest.fn((req, res, next) => next()),
+  refreshAccessToken: jest.fn((req, res, next) => next()),
+  optionalAuthentication: jest.fn((req, res, next) => next())
+}));
+
+// Also mock the plant model to avoid issues
+jest.mock('../src/models/plant', () => ({
+  getAllPlants: jest.fn(),
+  getPlantById: jest.fn(),
+  createPlant: jest.fn(),
+  updatePlant: jest.fn(),
+  deletePlant: jest.fn()
+}));
+
+const request = require('supertest');
+const app = require('../src/app');
+const userModel = require('../src/models/user');
+
+// Valid MongoDB ObjectId for testing
+const VALID_USER_ID = '507f1f77bcf86cd799439011';
+const OTHER_USER_ID = '507f1f77bcf86cd799439022';
+const VALID_CARD_ID = '507f1f77bcf86cd799439033';
+
+describe('User Authentication for Encyclopedia and Context Cards', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Encyclopedia endpoints with authentication', () => {
+    it('should allow a user to access their own encyclopedia data', async () => {
+      userModel.getEncyclopedia.mockResolvedValue('Test encyclopedia data');
+      
+      const res = await request(app)
+        .get(`/api/users/${VALID_USER_ID}/encyclopedia`)
+        .set('Authorization', 'Bearer valid_token_for_user1');
+        
+      expect(res.statusCode).toEqual(200);
+      expect(res.body).toHaveProperty('encyclopedia', 'Test encyclopedia data');
+    });
+
+    it('should deny access to another user\'s encyclopedia data', async () => {
+      const res = await request(app)
+        .get(`/api/users/${VALID_USER_ID}/encyclopedia`)
+        .set('Authorization', 'Bearer valid_token_for_user2');
+        
+      expect(res.statusCode).toEqual(403);
+      expect(res.body).toHaveProperty('error', 'You can only access your own encyclopedia data');
+    });
+
+    it('should require authentication for encyclopedia access', async () => {
+      const res = await request(app)
+        .get(`/api/users/${VALID_USER_ID}/encyclopedia`);
+        
+      expect(res.statusCode).toEqual(401);
+      expect(res.body).toHaveProperty('error', 'Authentication required');
+    });
+
+    it('should allow a user to update their own encyclopedia data', async () => {
+      const encyclopediaData = 'Updated encyclopedia data';
+      userModel.updateEncyclopedia.mockResolvedValue(encyclopediaData);
+      
+      const res = await request(app)
+        .post(`/api/users/${VALID_USER_ID}/encyclopedia`)
+        .set('Authorization', 'Bearer valid_token_for_user1')
+        .send({ encyclopedia: encyclopediaData });
+        
+      expect(res.statusCode).toEqual(200);
+      expect(res.body).toHaveProperty('encyclopedia', encyclopediaData);
+    });
+
+    it('should deny updates to another user\'s encyclopedia data', async () => {
+      const res = await request(app)
+        .post(`/api/users/${VALID_USER_ID}/encyclopedia`)
+        .set('Authorization', 'Bearer valid_token_for_user2')
+        .send({ encyclopedia: 'Test data' });
+        
+      expect(res.statusCode).toEqual(403);
+      expect(res.body).toHaveProperty('error', 'You can only update your own encyclopedia data');
+    });
+  });
+
+  describe('Context Cards endpoints with authentication', () => {
+    const sampleContextCard = {
+      id: VALID_CARD_ID,
+      title: 'Test Card',
+      content: 'Test content',
+      createdAt: new Date(),
+      updatedAt: new Date()
+    };
+
+    it('should allow a user to get their own context cards', async () => {
+      userModel.getContextCards.mockResolvedValue([sampleContextCard]);
+      
+      const res = await request(app)
+        .get(`/api/users/${VALID_USER_ID}/context-cards`)
+        .set('Authorization', 'Bearer valid_token_for_user1');
+        
+      expect(res.statusCode).toEqual(200);
+      expect(res.body).toHaveProperty('contextCards');
+      expect(res.body.contextCards).toHaveLength(1);
+      expect(res.body.contextCards[0]).toHaveProperty('id', VALID_CARD_ID);
+    });
+
+    it('should deny access to another user\'s context cards', async () => {
+      const res = await request(app)
+        .get(`/api/users/${VALID_USER_ID}/context-cards`)
+        .set('Authorization', 'Bearer valid_token_for_user2');
+        
+      expect(res.statusCode).toEqual(403);
+      expect(res.body).toHaveProperty('error', 'You can only access your own context cards');
+    });
+
+    it('should allow a user to create a context card for their account', async () => {
+      userModel.createContextCard.mockResolvedValue(sampleContextCard);
+      
+      const res = await request(app)
+        .post(`/api/users/${VALID_USER_ID}/context-cards`)
+        .set('Authorization', 'Bearer valid_token_for_user1')
+        .send({ title: 'Test Card', content: 'Test content' });
+        
+      expect(res.statusCode).toEqual(201);
+      expect(res.body).toHaveProperty('contextCard');
+      expect(res.body.contextCard).toHaveProperty('id', VALID_CARD_ID);
+    });
+
+    it('should deny creating context cards for another user', async () => {
+      const res = await request(app)
+        .post(`/api/users/${VALID_USER_ID}/context-cards`)
+        .set('Authorization', 'Bearer valid_token_for_user2')
+        .send({ title: 'Test Card', content: 'Test content' });
+        
+      expect(res.statusCode).toEqual(403);
+      expect(res.body).toHaveProperty('error', 'You can only create context cards for your own account');
+    });
+
+    it('should allow a user to update their own context card', async () => {
+      userModel.updateContextCard.mockResolvedValue({
+        ...sampleContextCard,
+        title: 'Updated Card',
+        content: 'Updated content'
+      });
+      
+      const res = await request(app)
+        .put(`/api/users/${VALID_USER_ID}/context-cards/${VALID_CARD_ID}`)
+        .set('Authorization', 'Bearer valid_token_for_user1')
+        .send({ title: 'Updated Card', content: 'Updated content' });
+        
+      expect(res.statusCode).toEqual(200);
+      expect(res.body).toHaveProperty('contextCard');
+      expect(res.body.contextCard).toHaveProperty('title', 'Updated Card');
+      expect(res.body.contextCard).toHaveProperty('content', 'Updated content');
+    });
+
+    it('should deny updating context cards belonging to another user', async () => {
+      const res = await request(app)
+        .put(`/api/users/${VALID_USER_ID}/context-cards/${VALID_CARD_ID}`)
+        .set('Authorization', 'Bearer valid_token_for_user2')
+        .send({ title: 'Updated Card', content: 'Updated content' });
+        
+      expect(res.statusCode).toEqual(403);
+      expect(res.body).toHaveProperty('error', 'You can only update your own context cards');
+    });
+
+    it('should allow a user to delete their own context card', async () => {
+      userModel.deleteContextCard.mockResolvedValue(true);
+      
+      const res = await request(app)
+        .delete(`/api/users/${VALID_USER_ID}/context-cards/${VALID_CARD_ID}`)
+        .set('Authorization', 'Bearer valid_token_for_user1');
+        
+      expect(res.statusCode).toEqual(200);
+      expect(res.body).toHaveProperty('success', true);
+    });
+
+    it('should deny deleting context cards belonging to another user', async () => {
+      const res = await request(app)
+        .delete(`/api/users/${VALID_USER_ID}/context-cards/${VALID_CARD_ID}`)
+        .set('Authorization', 'Bearer valid_token_for_user2');
+        
+      expect(res.statusCode).toEqual(403);
+      expect(res.body).toHaveProperty('error', 'You can only delete your own context cards');
+    });
+  });
+}); 


### PR DESCRIPTION
Fixes #32

## Changes
- Updated encyclopedia tests to work with user authentication requirements
- Added authentication token mocking to the users.test.js file
- Made the authentication token validator more flexible to support testing 404 scenarios
- All tests now pass, including system integration tests

## Testing
1. Run all tests with `./run_all_tests.sh` to verify all tests pass
2. Verify that encyclopedia endpoints properly enforce authentication
3. Verify that users can only access their own encyclopedia data

## Implementation Notes
- This completes subtask 4 of issue #14 (Encyclopedia & Context Card Association)
- Authentication middleware now protects all encyclopedia endpoints
- User data isolation is maintained for encyclopedia contexts
