### PR TITLE
[#33] Add Authentication UI Components

### DIFF
--- a/gardenbook-ui/__tests__/api/auth.test.ts
+++ b/gardenbook-ui/__tests__/api/auth.test.ts
@@ -1,0 +1,184 @@
+import {
+  registerUser,
+  loginUser,
+  logoutUser,
+  requestPasswordReset,
+  resetPassword,
+  getCurrentUser
+} from '../../app/api/auth';
+
+// Mock global fetch
+global.fetch = jest.fn();
+
+describe('Auth API Client', () => {
+  const mockFetch = global.fetch as jest.Mock;
+  
+  beforeEach(() => {
+    mockFetch.mockClear();
+    mockFetch.mockImplementation(() => 
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ success: true }),
+      })
+    );
+  });
+  
+  describe('registerUser', () => {
+    test('calls correct endpoint with right data', async () => {
+      const userData = {
+        username: 'testuser',
+        email: 'test@example.com',
+        password: 'password123',
+      };
+      
+      await registerUser(userData);
+      
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/auth/register'),
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+          }),
+          body: JSON.stringify(userData),
+        })
+      );
+    });
+    
+    test('throws error on API failure', async () => {
+      mockFetch.mockImplementationOnce(() => 
+        Promise.resolve({
+          ok: false,
+          json: () => Promise.resolve({ message: 'Registration failed' }),
+        })
+      );
+      
+      await expect(registerUser({
+        username: 'testuser',
+        email: 'test@example.com',
+        password: 'password123',
+      })).rejects.toThrow('Registration failed');
+    });
+  });
+  
+  describe('loginUser', () => {
+    test('calls correct endpoint with right data', async () => {
+      const loginData = {
+        email: 'test@example.com',
+        password: 'password123',
+        rememberMe: true,
+      };
+      
+      await loginUser(loginData);
+      
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/auth/login'),
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+          }),
+          body: JSON.stringify(loginData),
+          credentials: 'include',
+        })
+      );
+    });
+    
+    test('throws error on API failure', async () => {
+      mockFetch.mockImplementationOnce(() => 
+        Promise.resolve({
+          ok: false,
+          json: () => Promise.resolve({ message: 'Invalid credentials' }),
+        })
+      );
+      
+      await expect(loginUser({
+        email: 'test@example.com',
+        password: 'wrong-password',
+      })).rejects.toThrow('Invalid credentials');
+    });
+  });
+  
+  describe('logoutUser', () => {
+    test('calls correct endpoint with credentials included', async () => {
+      await logoutUser();
+      
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/auth/logout'),
+        expect.objectContaining({
+          method: 'POST',
+          credentials: 'include',
+        })
+      );
+    });
+  });
+  
+  describe('requestPasswordReset', () => {
+    test('calls correct endpoint with right data', async () => {
+      const resetData = {
+        email: 'test@example.com',
+      };
+      
+      await requestPasswordReset(resetData);
+      
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/auth/forgot-password'),
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+          }),
+          body: JSON.stringify(resetData),
+        })
+      );
+    });
+  });
+  
+  describe('resetPassword', () => {
+    test('calls correct endpoint with right data', async () => {
+      const resetData = {
+        token: 'reset-token-123',
+        password: 'new-password',
+      };
+      
+      await resetPassword(resetData);
+      
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/auth/reset-password'),
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+          }),
+          body: JSON.stringify(resetData),
+        })
+      );
+    });
+  });
+  
+  describe('getCurrentUser', () => {
+    test('calls correct endpoint with credentials included', async () => {
+      await getCurrentUser();
+      
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/auth/me'),
+        expect.objectContaining({
+          method: 'GET',
+          credentials: 'include',
+        })
+      );
+    });
+    
+    test('returns null on 401 unauthorized', async () => {
+      mockFetch.mockImplementationOnce(() => 
+        Promise.resolve({
+          ok: false,
+          status: 401,
+        })
+      );
+      
+      const result = await getCurrentUser();
+      expect(result).toBeNull();
+    });
+  });
+}); 

--- a/gardenbook-ui/__tests__/components/auth/FormInput.test.tsx
+++ b/gardenbook-ui/__tests__/components/auth/FormInput.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import FormInput from '../../../app/components/auth/FormInput';
+
+describe('FormInput Component', () => {
+  const mockOnChange = jest.fn();
+  const mockOnBlur = jest.fn();
+  
+  beforeEach(() => {
+    mockOnChange.mockClear();
+    mockOnBlur.mockClear();
+  });
+  
+  test('renders with required props', () => {
+    render(
+      <FormInput
+        id="test-input"
+        label="Test Label"
+        type="text"
+        value="Test Value"
+        onChange={mockOnChange}
+      />
+    );
+    
+    const input = screen.getByLabelText('Test Label');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue('Test Value');
+    expect(input).toHaveAttribute('id', 'test-input');
+    expect(input).toHaveAttribute('type', 'text');
+  });
+  
+  test('renders with required flag', () => {
+    render(
+      <FormInput
+        id="test-input"
+        label="Test Label"
+        type="text"
+        value="Test Value"
+        onChange={mockOnChange}
+        required
+      />
+    );
+    
+    const label = screen.getByText(/Test Label/);
+    const requiredIndicator = screen.getByText('*');
+    expect(requiredIndicator).toBeInTheDocument();
+    expect(requiredIndicator.tagName).toBe('SPAN');
+    expect(requiredIndicator).toHaveClass('text-red-500');
+  });
+  
+  test('displays error message', () => {
+    render(
+      <FormInput
+        id="test-input"
+        label="Test Label"
+        type="text"
+        value="Test Value"
+        onChange={mockOnChange}
+        error="This is an error message"
+      />
+    );
+    
+    const errorMessage = screen.getByText('This is an error message');
+    expect(errorMessage).toBeInTheDocument();
+    expect(errorMessage).toHaveClass('text-red-500');
+    
+    const input = screen.getByLabelText('Test Label');
+    expect(input).toHaveClass('border-red-500');
+  });
+  
+  test('calls onChange when input changes', () => {
+    render(
+      <FormInput
+        id="test-input"
+        label="Test Label"
+        type="text"
+        value="Test Value"
+        onChange={mockOnChange}
+      />
+    );
+    
+    const input = screen.getByLabelText('Test Label');
+    fireEvent.change(input, { target: { value: 'New Value' } });
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+  });
+  
+  test('calls onBlur when input loses focus', () => {
+    render(
+      <FormInput
+        id="test-input"
+        label="Test Label"
+        type="text"
+        value="Test Value"
+        onChange={mockOnChange}
+        onBlur={mockOnBlur}
+      />
+    );
+    
+    const input = screen.getByLabelText('Test Label');
+    fireEvent.blur(input);
+    expect(mockOnBlur).toHaveBeenCalledTimes(1);
+  });
+}); 

--- a/gardenbook-ui/app/api/auth.ts
+++ b/gardenbook-ui/app/api/auth.ts
@@ -1,0 +1,143 @@
+// Authentication API client functions
+
+interface RegisterData {
+  username: string;
+  email: string;
+  password: string;
+}
+
+interface LoginData {
+  email: string;
+  password: string;
+  rememberMe?: boolean;
+}
+
+interface PasswordResetRequestData {
+  email: string;
+}
+
+interface PasswordResetData {
+  token: string;
+  password: string;
+}
+
+const API_URL = process.env.NEXT_PUBLIC_NODE_API_URL || 'http://localhost:3001';
+
+/**
+ * Register a new user
+ */
+export async function registerUser(data: RegisterData) {
+  const response = await fetch(`${API_URL}/api/auth/register`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.message || 'Registration failed');
+  }
+
+  return response.json();
+}
+
+/**
+ * Login a user
+ */
+export async function loginUser(data: LoginData) {
+  const response = await fetch(`${API_URL}/api/auth/login`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+    credentials: 'include', // Important for cookies
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.message || 'Login failed');
+  }
+
+  return response.json();
+}
+
+/**
+ * Logout the current user
+ */
+export async function logoutUser() {
+  const response = await fetch(`${API_URL}/api/auth/logout`, {
+    method: 'POST',
+    credentials: 'include', // Important for cookies
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.message || 'Logout failed');
+  }
+
+  return response.json();
+}
+
+/**
+ * Request a password reset
+ */
+export async function requestPasswordReset(data: PasswordResetRequestData) {
+  const response = await fetch(`${API_URL}/api/auth/forgot-password`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.message || 'Password reset request failed');
+  }
+
+  return response.json();
+}
+
+/**
+ * Reset password with token
+ */
+export async function resetPassword(data: PasswordResetData) {
+  const response = await fetch(`${API_URL}/api/auth/reset-password`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.message || 'Password reset failed');
+  }
+
+  return response.json();
+}
+
+/**
+ * Get the current user
+ */
+export async function getCurrentUser() {
+  const response = await fetch(`${API_URL}/api/auth/me`, {
+    method: 'GET',
+    credentials: 'include', // Important for cookies
+  });
+
+  if (!response.ok) {
+    // If 401, user is not logged in
+    if (response.status === 401) {
+      return null;
+    }
+    const errorData = await response.json();
+    throw new Error(errorData.message || 'Failed to get current user');
+  }
+
+  return response.json();
+} 

--- a/gardenbook-ui/app/auth/forgot-password/page.tsx
+++ b/gardenbook-ui/app/auth/forgot-password/page.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState, FormEvent } from 'react';
+import Link from 'next/link';
+import AuthCard from '../../components/auth/AuthCard';
+import FormInput from '../../components/auth/FormInput';
+import Button from '../../components/auth/Button';
+import { requestPasswordReset } from '../../api/auth';
+
+export default function ForgotPasswordPage() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
+
+  const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setEmail(e.target.value);
+    
+    // Clear error when user starts typing again
+    if (error) {
+      setError('');
+    }
+  };
+
+  const validateForm = (): boolean => {
+    if (!email.trim()) {
+      setError('Email is required');
+      return false;
+    }
+    
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      setError('Please enter a valid email address');
+      return false;
+    }
+    
+    return true;
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    
+    if (!validateForm()) return;
+    
+    setIsLoading(true);
+    setError('');
+    
+    try {
+      await requestPasswordReset({ email });
+      setSuccessMessage('If an account exists with this email, you will receive password reset instructions shortly.');
+      setEmail(''); // Clear the form
+    } catch {
+      // For security reasons, we don't want to reveal if an email exists or not
+      // So we show the same success message even if the request fails
+      setSuccessMessage('If an account exists with this email, you will receive password reset instructions shortly.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <AuthCard 
+      title="Reset Your Password" 
+      footer={
+        <p className="text-sm text-center text-gray-600">
+          Remember your password?{' '}
+          <Link href="/auth/login" className="text-purple-600 hover:underline">
+            Sign in
+          </Link>
+        </p>
+      }
+    >
+      {successMessage ? (
+        <div className="text-center">
+          <div className="mb-6 p-3 bg-green-100 border border-green-300 text-green-700 rounded">
+            {successMessage}
+          </div>
+          
+          <Link href="/auth/login">
+            <Button variant="outline" fullWidth>
+              Return to Login
+            </Button>
+          </Link>
+        </div>
+      ) : (
+        <>
+          <p className="mb-6 text-sm text-gray-600">
+            Enter the email address associated with your account, and we&apos;ll send you a link to reset your password.
+          </p>
+          
+          {error && (
+            <div className="mb-4 p-3 bg-red-100 border border-red-300 text-red-700 rounded">
+              {error}
+            </div>
+          )}
+          
+          <form onSubmit={handleSubmit}>
+            <FormInput
+              id="email"
+              label="Email"
+              type="email"
+              value={email}
+              onChange={handleEmailChange}
+              error=""
+              required
+              autoComplete="email"
+            />
+            
+            <div className="mt-6">
+              <Button 
+                type="submit" 
+                variant="primary" 
+                isLoading={isLoading}
+                disabled={isLoading}
+                fullWidth
+              >
+                Send Reset Link
+              </Button>
+            </div>
+          </form>
+        </>
+      )}
+    </AuthCard>
+  );
+} 

--- a/gardenbook-ui/app/auth/login/page.tsx
+++ b/gardenbook-ui/app/auth/login/page.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useState, FormEvent, useEffect, Suspense } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import AuthCard from '../../components/auth/AuthCard';
+import FormInput from '../../components/auth/FormInput';
+import Button from '../../components/auth/Button';
+import { loginUser } from '../../api/auth';
+
+// This component will be used inside the Suspense boundary
+function LoginContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isLoading, setIsLoading] = useState(false);
+  const [formData, setFormData] = useState({
+    email: '',
+    password: '',
+    rememberMe: false,
+  });
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitError, setSubmitError] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
+
+  useEffect(() => {
+    // Display success message if user just registered
+    const registered = searchParams.get('registered');
+    if (registered === 'true') {
+      setSuccessMessage('Registration successful! Please log in with your new account.');
+    }
+  }, [searchParams]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value, type, checked } = e.target;
+    const newValue = type === 'checkbox' ? checked : value;
+    
+    setFormData(prev => ({ ...prev, [name]: newValue }));
+    
+    // Clear field-specific error when user starts typing again
+    if (errors[name]) {
+      setErrors(prev => ({ ...prev, [name]: '' }));
+    }
+    
+    // Clear submit error when form changes
+    if (submitError) {
+      setSubmitError('');
+    }
+  };
+
+  const validateForm = (): boolean => {
+    const newErrors: Record<string, string> = {};
+    
+    // Email validation
+    if (!formData.email.trim()) {
+      newErrors.email = 'Email is required';
+    }
+    
+    // Password validation
+    if (!formData.password) {
+      newErrors.password = 'Password is required';
+    }
+    
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    
+    if (!validateForm()) return;
+    
+    setIsLoading(true);
+    setSubmitError('');
+    setSuccessMessage('');
+    
+    try {
+      await loginUser({
+        email: formData.email,
+        password: formData.password,
+        rememberMe: formData.rememberMe,
+      });
+      
+      // Redirect to home page after successful login
+      router.push('/myplants');
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : 'Login failed. Please check your credentials and try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <AuthCard 
+      title="Sign in to your account" 
+      footer={
+        <p className="text-sm text-center text-gray-600">
+          Don&apos;t have an account?{' '}
+          <Link href="/auth/register" className="text-purple-600 hover:underline">
+            Create one
+          </Link>
+        </p>
+      }
+    >
+      {successMessage && (
+        <div className="mb-4 p-3 bg-green-100 border border-green-300 text-green-700 rounded">
+          {successMessage}
+        </div>
+      )}
+      
+      {submitError && (
+        <div className="mb-4 p-3 bg-red-100 border border-red-300 text-red-700 rounded">
+          {submitError}
+        </div>
+      )}
+      
+      <form onSubmit={handleSubmit}>
+        <FormInput
+          id="email"
+          label="Email"
+          type="email"
+          value={formData.email}
+          onChange={handleChange}
+          error={errors.email}
+          required
+          autoComplete="email"
+        />
+        
+        <FormInput
+          id="password"
+          label="Password"
+          type="password"
+          value={formData.password}
+          onChange={handleChange}
+          error={errors.password}
+          required
+          autoComplete="current-password"
+        />
+        
+        <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center">
+            <input
+              id="rememberMe"
+              name="rememberMe"
+              type="checkbox"
+              checked={formData.rememberMe}
+              onChange={handleChange}
+              className="h-4 w-4 rounded border-gray-300 text-purple-600 focus:ring-purple-500"
+            />
+            <label htmlFor="rememberMe" className="ml-2 block text-sm text-gray-700">
+              Remember me
+            </label>
+          </div>
+          
+          <Link
+            href="/auth/forgot-password"
+            className="text-sm text-purple-600 hover:underline"
+          >
+            Forgot password?
+          </Link>
+        </div>
+        
+        <Button 
+          type="submit" 
+          variant="primary" 
+          isLoading={isLoading}
+          disabled={isLoading}
+          fullWidth
+        >
+          Sign in
+        </Button>
+      </form>
+    </AuthCard>
+  );
+}
+
+// Main component with Suspense boundary
+export default function LoginPage() {
+  return (
+    <Suspense fallback={<AuthCard title="Loading..."><p>Loading...</p></AuthCard>}>
+      <LoginContent />
+    </Suspense>
+  );
+} 

--- a/gardenbook-ui/app/auth/register/page.tsx
+++ b/gardenbook-ui/app/auth/register/page.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useState, FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import AuthCard from '../../components/auth/AuthCard';
+import FormInput from '../../components/auth/FormInput';
+import Button from '../../components/auth/Button';
+import { registerUser } from '../../api/auth';
+
+export default function RegisterPage() {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+  const [formData, setFormData] = useState({
+    username: '',
+    email: '',
+    password: '',
+    confirmPassword: '',
+  });
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitError, setSubmitError] = useState('');
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({ ...prev, [name]: value }));
+    
+    // Clear field-specific error when user starts typing again
+    if (errors[name]) {
+      setErrors(prev => ({ ...prev, [name]: '' }));
+    }
+    
+    // Clear submit error when form changes
+    if (submitError) {
+      setSubmitError('');
+    }
+  };
+
+  const validateForm = (): boolean => {
+    const newErrors: Record<string, string> = {};
+    
+    // Username validation
+    if (!formData.username.trim()) {
+      newErrors.username = 'Username is required';
+    } else if (formData.username.length < 3) {
+      newErrors.username = 'Username must be at least 3 characters';
+    }
+    
+    // Email validation
+    if (!formData.email.trim()) {
+      newErrors.email = 'Email is required';
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
+      newErrors.email = 'Please enter a valid email address';
+    }
+    
+    // Password validation
+    if (!formData.password) {
+      newErrors.password = 'Password is required';
+    } else if (formData.password.length < 8) {
+      newErrors.password = 'Password must be at least 8 characters';
+    }
+    
+    // Confirm password validation
+    if (formData.password !== formData.confirmPassword) {
+      newErrors.confirmPassword = 'Passwords do not match';
+    }
+    
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    
+    if (!validateForm()) return;
+    
+    setIsLoading(true);
+    setSubmitError('');
+    
+    try {
+      await registerUser({
+        username: formData.username,
+        email: formData.email,
+        password: formData.password,
+      });
+      
+      // Redirect to login page after successful registration
+      router.push('/auth/login?registered=true');
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : 'Registration failed. Please try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <AuthCard 
+      title="Create an Account" 
+      footer={
+        <p className="text-sm text-center text-gray-600">
+          Already have an account?{' '}
+          <Link href="/auth/login" className="text-purple-600 hover:underline">
+            Sign in
+          </Link>
+        </p>
+      }
+    >
+      {submitError && (
+        <div className="mb-4 p-3 bg-red-100 border border-red-300 text-red-700 rounded">
+          {submitError}
+        </div>
+      )}
+      
+      <form onSubmit={handleSubmit}>
+        <FormInput
+          id="username"
+          label="Username"
+          type="text"
+          value={formData.username}
+          onChange={handleChange}
+          error={errors.username}
+          required
+          autoComplete="username"
+        />
+        
+        <FormInput
+          id="email"
+          label="Email"
+          type="email"
+          value={formData.email}
+          onChange={handleChange}
+          error={errors.email}
+          required
+          autoComplete="email"
+        />
+        
+        <FormInput
+          id="password"
+          label="Password"
+          type="password"
+          value={formData.password}
+          onChange={handleChange}
+          error={errors.password}
+          required
+          autoComplete="new-password"
+        />
+        
+        <FormInput
+          id="confirmPassword"
+          label="Confirm Password"
+          type="password"
+          value={formData.confirmPassword}
+          onChange={handleChange}
+          error={errors.confirmPassword}
+          required
+          autoComplete="new-password"
+        />
+        
+        <div className="mt-6">
+          <Button 
+            type="submit" 
+            variant="primary" 
+            isLoading={isLoading}
+            disabled={isLoading}
+            fullWidth
+          >
+            Create Account
+          </Button>
+        </div>
+      </form>
+    </AuthCard>
+  );
+} 

--- a/gardenbook-ui/app/auth/reset-password/page.tsx
+++ b/gardenbook-ui/app/auth/reset-password/page.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useState, FormEvent, useEffect, Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import AuthCard from '../../components/auth/AuthCard';
+import FormInput from '../../components/auth/FormInput';
+import Button from '../../components/auth/Button';
+import { resetPassword } from '../../api/auth';
+
+// This component will be used inside the Suspense boundary
+function ResetPasswordContent() {
+  const searchParams = useSearchParams();
+  const [token, setToken] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [formData, setFormData] = useState({
+    password: '',
+    confirmPassword: '',
+  });
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitError, setSubmitError] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
+
+  useEffect(() => {
+    // Get token from query parameters
+    const tokenParam = searchParams.get('token');
+    if (!tokenParam) {
+      setSubmitError('Reset token is missing. Please use the link from your email.');
+    } else {
+      setToken(tokenParam);
+    }
+  }, [searchParams]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({ ...prev, [name]: value }));
+    
+    // Clear field-specific error when user starts typing again
+    if (errors[name]) {
+      setErrors(prev => ({ ...prev, [name]: '' }));
+    }
+    
+    // Clear submit error when form changes
+    if (submitError) {
+      setSubmitError('');
+    }
+  };
+
+  const validateForm = (): boolean => {
+    const newErrors: Record<string, string> = {};
+    
+    // Password validation
+    if (!formData.password) {
+      newErrors.password = 'New password is required';
+    } else if (formData.password.length < 8) {
+      newErrors.password = 'Password must be at least 8 characters';
+    }
+    
+    // Confirm password validation
+    if (formData.password !== formData.confirmPassword) {
+      newErrors.confirmPassword = 'Passwords do not match';
+    }
+    
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    
+    if (!token) {
+      setSubmitError('Reset token is missing. Please use the link from your email.');
+      return;
+    }
+    
+    if (!validateForm()) return;
+    
+    setIsLoading(true);
+    setSubmitError('');
+    
+    try {
+      await resetPassword({
+        token,
+        password: formData.password,
+      });
+      
+      setSuccessMessage('Your password has been successfully reset!');
+      // Clear form data after successful reset
+      setFormData({
+        password: '',
+        confirmPassword: '',
+      });
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : 'Password reset failed. The link may have expired or is invalid.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <AuthCard title="Set New Password">
+      {successMessage ? (
+        <div className="text-center">
+          <div className="mb-6 p-3 bg-green-100 border border-green-300 text-green-700 rounded">
+            {successMessage}
+          </div>
+          
+          <Link href="/auth/login">
+            <Button variant="primary" fullWidth>
+              Go to Login
+            </Button>
+          </Link>
+        </div>
+      ) : (
+        <>
+          {submitError && (
+            <div className="mb-4 p-3 bg-red-100 border border-red-300 text-red-700 rounded">
+              {submitError}
+            </div>
+          )}
+          
+          <form onSubmit={handleSubmit}>
+            <FormInput
+              id="password"
+              label="New Password"
+              type="password"
+              value={formData.password}
+              onChange={handleChange}
+              error={errors.password}
+              required
+              autoComplete="new-password"
+            />
+            
+            <FormInput
+              id="confirmPassword"
+              label="Confirm New Password"
+              type="password"
+              value={formData.confirmPassword}
+              onChange={handleChange}
+              error={errors.confirmPassword}
+              required
+              autoComplete="new-password"
+            />
+            
+            <div className="mt-6">
+              <Button 
+                type="submit" 
+                variant="primary" 
+                isLoading={isLoading}
+                disabled={isLoading || !token}
+                fullWidth
+              >
+                Reset Password
+              </Button>
+            </div>
+            
+            <div className="mt-4 text-center">
+              <Link 
+                href="/auth/login" 
+                className="text-sm text-purple-600 hover:underline"
+              >
+                Back to Login
+              </Link>
+            </div>
+          </form>
+        </>
+      )}
+    </AuthCard>
+  );
+}
+
+// Main component with Suspense boundary
+export default function ResetPasswordPage() {
+  return (
+    <Suspense fallback={<AuthCard title="Loading..."><p>Loading...</p></AuthCard>}>
+      <ResetPasswordContent />
+    </Suspense>
+  );
+} 

--- a/gardenbook-ui/app/components/auth/AuthCard.tsx
+++ b/gardenbook-ui/app/components/auth/AuthCard.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import React from 'react';
+import Link from 'next/link';
+import { PiPlantFill } from 'react-icons/pi';
+
+interface AuthCardProps {
+  title: string;
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+}
+
+export default function AuthCard({ title, children, footer }: AuthCardProps) {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-100 p-4">
+      <div className="w-full max-w-md bg-white rounded-lg shadow-md overflow-hidden">
+        <div className="px-8 py-6">
+          <div className="flex justify-center mb-4">
+            <Link href="/" className="flex items-center gap-2">
+              <PiPlantFill size={32} className="text-purple-600" />
+              <span className="text-xl font-semibold text-gray-800">GardenBook</span>
+            </Link>
+          </div>
+          
+          <h2 className="text-center text-2xl font-bold text-gray-800 mb-6">{title}</h2>
+          
+          {children}
+        </div>
+        
+        {footer && (
+          <div className="px-8 py-4 bg-gray-50 border-t border-gray-200">
+            {footer}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+} 

--- a/gardenbook-ui/app/components/auth/Button.tsx
+++ b/gardenbook-ui/app/components/auth/Button.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import React from 'react';
+
+interface ButtonProps {
+  type?: 'button' | 'submit' | 'reset';
+  onClick?: () => void;
+  isLoading?: boolean;
+  disabled?: boolean;
+  variant?: 'primary' | 'secondary' | 'outline';
+  children: React.ReactNode;
+  fullWidth?: boolean;
+  className?: string;
+}
+
+export default function Button({
+  type = 'button',
+  onClick,
+  isLoading = false,
+  disabled = false,
+  variant = 'primary',
+  children,
+  fullWidth = false,
+  className = '',
+}: ButtonProps) {
+  
+  const baseClasses = 'px-4 py-2 rounded-md font-medium transition-colors duration-200 flex justify-center items-center';
+  
+  const variantClasses = {
+    primary: 'bg-purple-600 text-white hover:bg-purple-700 focus:ring-purple-500',
+    secondary: 'bg-gray-600 text-white hover:bg-gray-700 focus:ring-gray-500',
+    outline: 'bg-transparent text-purple-600 border border-purple-600 hover:bg-purple-50 focus:ring-purple-500',
+  };
+  
+  const widthClass = fullWidth ? 'w-full' : '';
+  const disabledClass = disabled || isLoading ? 'opacity-70 cursor-not-allowed' : '';
+  
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={disabled || isLoading}
+      className={`
+        ${baseClasses}
+        ${variantClasses[variant]}
+        ${widthClass}
+        ${disabledClass}
+        ${className}
+      `}
+    >
+      {isLoading ? (
+        <svg className="animate-spin -ml-1 mr-2 h-4 w-4 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+        </svg>
+      ) : null}
+      {children}
+    </button>
+  );
+} 

--- a/gardenbook-ui/app/components/auth/FormInput.tsx
+++ b/gardenbook-ui/app/components/auth/FormInput.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import React from 'react';
+
+interface FormInputProps {
+  id: string;
+  label: string;
+  type: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onBlur?: () => void;
+  error?: string;
+  required?: boolean;
+  placeholder?: string;
+  autoComplete?: string;
+}
+
+export default function FormInput({
+  id,
+  label,
+  type,
+  value,
+  onChange,
+  onBlur,
+  error,
+  required = false,
+  placeholder = '',
+  autoComplete,
+}: FormInputProps) {
+  return (
+    <div className="mb-4">
+      <label 
+        htmlFor={id} 
+        className="block text-sm font-medium text-gray-700 mb-1"
+      >
+        {label}
+        {required && <span className="text-red-500 ml-1">*</span>}
+      </label>
+      <input
+        id={id}
+        name={id}
+        type={type}
+        value={value}
+        onChange={onChange}
+        onBlur={onBlur}
+        required={required}
+        placeholder={placeholder}
+        autoComplete={autoComplete}
+        className={`
+          w-full px-3 py-2 rounded-md border
+          focus:outline-none focus:ring-2 focus:ring-purple-500
+          ${error ? 'border-red-500' : 'border-gray-300'}
+        `}
+      />
+      {error && (
+        <p className="mt-1 text-sm text-red-500">{error}</p>
+      )}
+    </div>
+  );
+} 


### PR DESCRIPTION
Fixes #33

## Changes
- Created UI components for user authentication:
  - Registration form with validation
  - Login form with validation and "Remember me" option
  - Forgot password request form
  - Password reset form
- Added API client functions for authentication endpoints
- Created shared components for forms and auth UI:
  - FormInput component with validation and error handling
  - Button component with loading state
  - AuthCard layout component
- Added tests for API client functions and components
- Fixed ESLint issues and Next.js warnings

## Testing
1. Register a new user via `/auth/register`
2. Login with created credentials via `/auth/login`
3. Test password reset flow via `/auth/forgot-password` and `/auth/reset-password`
4. Check validation works on all forms
5. Check all forms submit correctly to backend endpoints
6. Verify error handling works properly

## Screenshots
N/A - UI follows existing application design patterns
